### PR TITLE
Add auth interceptor

### DIFF
--- a/fableous-fe/src/Api.tsx
+++ b/fableous-fe/src/Api.tsx
@@ -1,5 +1,6 @@
 import axios, { AxiosRequestConfig } from "axios";
 import { configure } from "axios-hooks";
+import auth from "./Auth";
 
 const baseAPI =
   process.env.NODE_ENV === "development"
@@ -11,8 +12,23 @@ const baseWS =
     ? `${process.env.REACT_APP_BACKENDWS}`
     : `wss://${window.location.hostname}`;
 
+axios.interceptors.request.use();
 axios.defaults.baseURL = baseAPI;
+const onIntercept = (req: any) => {
+  console.log("intercepted");
+
+  if (auth.isAuthenticated()) {
+    req.headers.Authorization = auth.getToken();
+  } else {
+    auth.clearToken();
+  }
+
+  return req;
+};
+
+axios.interceptors.request.use(onIntercept, Promise.reject);
 const apiClient = axios.create();
+apiClient.interceptors.request.use(onIntercept, Promise.reject);
 
 configure({
   axios: apiClient,


### PR DESCRIPTION
description below is copied from comments in previous PR

I tried running on localhost, do we want to implement the following?

- redirect to homepage after successful login
- if login page is visited and user is already logged in, redirect to homepage too
- add login and register button to navbar only if user not logged in
- logout button on navbar if user logged in, which just clears token in localstorage
- these could be put into jira task and implemented later in another branch

one more thing @wahyuadt , in this file u save the token "Bearer abcdef..." as is, that exact format (with Bearer) is needed for rest API requests, but for websocket requests, the only thing needed it the token part (WITHOUT Bearer), so I think its better to save only the "abcdef..." part, and in interceptor, append it to "Bearere "