### PR TITLE
[FAB-81] fix: redirect to login page on 401 token expired

### DIFF
--- a/fableous-fe/src/App.tsx
+++ b/fableous-fe/src/App.tsx
@@ -4,6 +4,7 @@ import { SnackbarProvider } from "notistack";
 import AuthProvider from "./components/AuthProvider";
 import Navbar from "./components/Navbar";
 import Routes from "./Routes";
+import InjectAxiosRespInterceptor from "./components/InjectAxiosRespInterceptor";
 
 export default function App() {
   return (
@@ -11,6 +12,7 @@ export default function App() {
       <AuthProvider>
         <SnackbarProvider maxSnack={3}>
           <Router>
+            <InjectAxiosRespInterceptor />
             <Navbar />
             <Container className="pt-5">
               <Grid container>

--- a/fableous-fe/src/components/InjectAxiosRespInterceptor.tsx
+++ b/fableous-fe/src/components/InjectAxiosRespInterceptor.tsx
@@ -1,0 +1,19 @@
+import { useContext, useEffect } from "react";
+import { useHistory } from "react-router-dom";
+import { setupResponseInterceptor } from "../Api";
+import { AuthContext } from "./AuthProvider";
+
+export default function InjectAxiosRespInterceptor() {
+  const history = useHistory();
+  const [, , , clearToken] = useContext(AuthContext);
+
+  useEffect(() => {
+    setupResponseInterceptor(() => {
+      clearToken();
+      history.push("/login");
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [history]);
+
+  return null;
+}


### PR DESCRIPTION
followed a stackoverflow answer https://stackoverflow.com/a/68314778/11337921

can test by running this on console 

`localStorage.setItem("token", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxNWQ0OWNmZS01YjNkLTRiOGItYmVjNS1mMDcwYjE5YjI0N2YiLCJleHAiOjE2Mjk4ODc4MjksImlhdCI6MTYyOTcxNTAyOX0.c9ShN-aV_G47hzx2aMgB6EU2MLEshba2fcUHeX9fK7I")`

to note, if u look at the console, theres this error after running above command and reloading: `Warning: Can't perform a React state update on an unmounted component.`, however I checked that token state in AuthProvider and localstorage is properly set to empty string, so should be fine (?)