### PR TITLE
[FAB-82] On-screen keyboard

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Provide Env File
         run: |
           echo "${{ secrets.FE_ENV_FILE }}" > ${{ env.APPLICATION }}-${{ matrix.service }}/.env.production
-          echo "REACT_APP_VERSION=${{ env.RELEASE_VERSION }}:${GITHUB_REF#refs/heads/}@${GITHUB_SHA}" >> ${{ env.APPLICATION }}-${{ matrix.service }}/.env.production
+          echo "REACT_APP_VERSION=${{ env.RELEASE_VERSION }}:${GITHUB_REF#refs/heads/}@${GITHUB_SHA:0:7}" >> ${{ env.APPLICATION }}-${{ matrix.service }}/.env.production
       - name: Build and Push Image
         uses: docker/build-push-action@v2
         with:

--- a/fableous-fe/src/components/canvas/Canvas.tsx
+++ b/fableous-fe/src/components/canvas/Canvas.tsx
@@ -810,7 +810,8 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
         if (editingTextId) {
           const mockInput = document.createElement("input");
           mockInput.id = "MOCK_INPUT";
-          mockInput.style.display = "none";
+          mockInput.style.opacity = "0";
+          mockInput.style.position = "absolute";
           mockInput.focus();
         } else {
           document.getElementById("MOCK_INPUT")?.remove();

--- a/fableous-fe/src/components/canvas/Canvas.tsx
+++ b/fableous-fe/src/components/canvas/Canvas.tsx
@@ -94,10 +94,7 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
       console.log(show);
       if (show) {
         onScreenKeyboardRef.current.focus();
-        setTimeout(() => onScreenKeyboardRef.current.focus(), 500);
         console.log(onScreenKeyboardRef.current);
-      } else {
-        onScreenKeyboardRef.current.blur();
       }
     };
 

--- a/fableous-fe/src/components/canvas/Canvas.tsx
+++ b/fableous-fe/src/components/canvas/Canvas.tsx
@@ -67,6 +67,9 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
     let FRAME_COUNTER = 0;
     const { layer, role, pageNum, isShown, setCursor, wsConn } = props;
     const canvasRef = ref as MutableRefObject<HTMLCanvasElement>;
+    const onScreenKeyboardRef = useRef<HTMLInputElement>(
+      document.createElement("input")
+    );
     const [allowDrawing, setAllowDrawing] = useState(false);
     const [dragging, setDragging] = useState(false);
     const [hasLifted, setHasLifted] = useState(false);
@@ -808,13 +811,9 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
     useEffect(() => {
       if (isShown && role !== ControllerRole.Hub) {
         if (editingTextId) {
-          const mockInput = document.createElement("input");
-          mockInput.id = "MOCK_INPUT";
-          mockInput.style.opacity = "0";
-          mockInput.style.position = "absolute";
-          mockInput.focus();
+          setTimeout(() => onScreenKeyboardRef.current.focus(), 0);
         } else {
-          document.getElementById("MOCK_INPUT")?.remove();
+          onScreenKeyboardRef.current.blur();
         }
       }
     }, [isShown, editingTextId, role]);
@@ -833,7 +832,7 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
             borderWidth: 4,
             width: "100%",
             // allows onPointerMove to be fired continuously on touch,
-            // else will be treated as pan gesture leading to short strokes
+            // else will be treated as pan .fgesture leading to short strokes
             touchAction: "none",
             msTouchAction: "none",
             msTouchSelect: "none",
@@ -982,6 +981,11 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
             </Button>
           </div>
         )}
+        <input
+          id="MOCK_INPUT"
+          ref={onScreenKeyboardRef}
+          style={{ position: "absolute", pointerEvents: "none" }}
+        />
       </>
     );
   }

--- a/fableous-fe/src/components/canvas/Canvas.tsx
+++ b/fableous-fe/src/components/canvas/Canvas.tsx
@@ -804,6 +804,20 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
       }
     }, [editingTextId, textId, placeCheckpoint]);
 
+    // show and hide onscreen keyboard for touchscreen devices
+    useEffect(() => {
+      if (isShown && role !== ControllerRole.Hub) {
+        if (editingTextId) {
+          const mockInput = document.createElement("input");
+          mockInput.id = "MOCK_INPUT";
+          mockInput.style.display = "none";
+          mockInput.focus();
+        } else {
+          document.getElementById("MOCK_INPUT")?.remove();
+        }
+      }
+    }, [isShown, editingTextId, role]);
+
     return (
       <>
         <canvas

--- a/fableous-fe/src/components/canvas/Canvas.tsx
+++ b/fableous-fe/src/components/canvas/Canvas.tsx
@@ -811,7 +811,7 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
     useEffect(() => {
       if (isShown && role !== ControllerRole.Hub) {
         if (editingTextId) {
-          setTimeout(() => onScreenKeyboardRef.current.focus(), 0);
+          setTimeout(() => onScreenKeyboardRef.current.focus(), 100);
         } else {
           onScreenKeyboardRef.current.blur();
         }
@@ -985,6 +985,13 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
           id="MOCK_INPUT"
           ref={onScreenKeyboardRef}
           style={{ position: "absolute", pointerEvents: "none" }}
+        />
+        <input
+          style={{
+            position: "absolute",
+            top: 128,
+            borderWidth: 4,
+          }}
         />
       </>
     );

--- a/fableous-fe/src/components/canvas/Canvas.tsx
+++ b/fableous-fe/src/components/canvas/Canvas.tsx
@@ -699,6 +699,7 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
     const wrapPointerHandler =
       (handler: (event: SimplePointerEventData) => void) =>
       (event: React.PointerEvent<HTMLCanvasElement>) => {
+        event.preventDefault();
         if (event.isPrimary) {
           handler({ clientX: event.clientX, clientY: event.clientY });
         }

--- a/fableous-fe/src/components/canvas/Canvas.tsx
+++ b/fableous-fe/src/components/canvas/Canvas.tsx
@@ -990,7 +990,7 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
         <input
           id="MOCK_INPUT"
           ref={onScreenKeyboardRef}
-          style={{ position: "absolute", pointerEvents: "none" }}
+          style={{ position: "absolute", top: 256, pointerEvents: "none" }}
         />
         <input
           style={{

--- a/fableous-fe/src/components/canvas/Canvas.tsx
+++ b/fableous-fe/src/components/canvas/Canvas.tsx
@@ -90,6 +90,17 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
     const [toolWidth, setToolWidth] = useState(8 * SCALE);
     const [, setCheckpointHistory] = useState<Checkpoint[]>([]);
 
+    const showKeyboard = (show: boolean) => {
+      console.log(show);
+      if (show) {
+        onScreenKeyboardRef.current.focus();
+        setTimeout(() => onScreenKeyboardRef.current.focus(), 500);
+        console.log(onScreenKeyboardRef.current);
+      } else {
+        onScreenKeyboardRef.current.blur();
+      }
+    };
+
     const placePaint = useCallback(
       (
         x1: number,
@@ -359,6 +370,7 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
         } else if (editingTextId) {
           // deselect currently editing text
           setEditingTextId(0);
+          showKeyboard(false);
         } else {
           // insert new text
           placeText(x, y, textId, "", 18);
@@ -673,6 +685,9 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
       if (toolMode === ToolMode.Paint || toolMode === ToolMode.Fill) {
         placeCheckpoint(toolMode);
       }
+      if (editingTextId && !dragging) {
+        showKeyboard(true);
+      }
       if (dragging) {
         setEditingTextId(0);
       }
@@ -701,6 +716,7 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
         if (!shape) return;
         if (key === "Escape" || key === "Enter") {
           setEditingTextId(0);
+          showKeyboard(false);
         }
         if (key.length === 1 || key === "Backspace") {
           if (key.length === 1) {
@@ -806,20 +822,6 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
         placeCheckpoint(ToolMode.Text);
       }
     }, [editingTextId, textId, placeCheckpoint]);
-
-    // show and hide onscreen keyboard for touchscreen devices
-    useEffect(() => {
-      if (isShown && role !== ControllerRole.Hub) {
-        if (editingTextId) {
-          onScreenKeyboardRef.current.focus();
-          setTimeout(() => onScreenKeyboardRef.current.focus(), 500);
-          console.log(editingTextId);
-          console.log(onScreenKeyboardRef.current);
-        } else {
-          onScreenKeyboardRef.current.blur();
-        }
-      }
-    }, [isShown, editingTextId, role]);
 
     return (
       <>

--- a/fableous-fe/src/components/canvas/Canvas.tsx
+++ b/fableous-fe/src/components/canvas/Canvas.tsx
@@ -798,9 +798,7 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
             placeUndo();
           }
         };
-        if (isShown) {
-          document.addEventListener("keydown", undoListener);
-        }
+        document.addEventListener("keydown", undoListener);
         return () => {
           document.removeEventListener("keydown", undoListener);
         };

--- a/fableous-fe/src/components/canvas/Canvas.tsx
+++ b/fableous-fe/src/components/canvas/Canvas.tsx
@@ -792,18 +792,21 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
 
     // initialize undo shortcut listener
     useEffect(() => {
-      const undoListener = (event: KeyboardEvent) => {
-        if (event.key === "z" && (event.ctrlKey || event.metaKey)) {
-          placeUndo();
+      if (isShown && role !== ControllerRole.Hub) {
+        const undoListener = (event: KeyboardEvent) => {
+          if (event.key === "z" && (event.ctrlKey || event.metaKey)) {
+            placeUndo();
+          }
+        };
+        if (isShown) {
+          document.addEventListener("keydown", undoListener);
         }
-      };
-      if (isShown) {
-        document.addEventListener("keydown", undoListener);
+        return () => {
+          document.removeEventListener("keydown", undoListener);
+        };
       }
-      return () => {
-        document.removeEventListener("keydown", undoListener);
-      };
-    }, [isShown, layer, placeUndo]);
+      return () => {};
+    }, [isShown, layer, placeUndo, role]);
 
     // start text layer animation
     useEffect(() => {

--- a/fableous-fe/src/components/canvas/Canvas.tsx
+++ b/fableous-fe/src/components/canvas/Canvas.tsx
@@ -844,7 +844,7 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
             borderWidth: 4,
             width: "100%",
             // allows onPointerMove to be fired continuously on touch,
-            // else will be treated as pan .fgesture leading to short strokes
+            // else will be treated as pan gesture leading to short strokes
             touchAction: "none",
             msTouchAction: "none",
             msTouchSelect: "none",

--- a/fableous-fe/src/components/canvas/Canvas.tsx
+++ b/fableous-fe/src/components/canvas/Canvas.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/media-has-caption */
 /* eslint-disable no-param-reassign */
 /* eslint-disable no-plusplus */
@@ -91,10 +93,10 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
     const [, setCheckpointHistory] = useState<Checkpoint[]>([]);
 
     const showKeyboard = (show: boolean) => {
-      console.log(show);
       if (show) {
         onScreenKeyboardRef.current.focus();
-        console.log(onScreenKeyboardRef.current);
+      } else {
+        onScreenKeyboardRef.current.blur();
       }
     };
 
@@ -364,7 +366,6 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
         if (targetId) {
           // edit clicked text
           setEditingTextId(targetId);
-          showKeyboard(true);
         } else if (editingTextId) {
           // deselect currently editing text
           setEditingTextId(0);
@@ -375,7 +376,6 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
           setEditingTextId(textId);
           setTextId(textId + 1);
           setHasLifted(true); // disable dragging for new texts
-          showKeyboard(true);
         }
       } else if (targetShape) {
         window.speechSynthesis.speak(
@@ -694,10 +694,11 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
     };
 
     const wrapPointerHandler =
-      (handler: (event: SimplePointerEventData) => void) =>
+      (handler: ((event: SimplePointerEventData) => void) | undefined) =>
       (event: React.PointerEvent<HTMLCanvasElement>) => {
         event.preventDefault();
-        if (event.isPrimary) {
+        event.stopPropagation();
+        if (event.isPrimary && handler) {
           handler({ clientX: event.clientX, clientY: event.clientY });
         }
       };
@@ -828,8 +829,16 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
           onPointerDown={wrapPointerHandler(onPointerDown)}
           onPointerMove={wrapPointerHandler(onPointerMove)}
           onPointerUp={wrapPointerHandler(onPointerUp)}
+          onPointerCancel={wrapPointerHandler(undefined)}
+          onPointerEnter={wrapPointerHandler(undefined)}
+          onPointerLeave={wrapPointerHandler(undefined)}
+          onPointerOut={wrapPointerHandler(undefined)}
+          onPointerOver={wrapPointerHandler(undefined)}
           onContextMenu={(e) => {
             e.preventDefault();
+          }}
+          onClick={() => {
+            if (editingTextId) showKeyboard(true);
           }}
           style={{
             borderWidth: 4,
@@ -985,15 +994,12 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
           </div>
         )}
         <input
-          id="MOCK_INPUT"
           ref={onScreenKeyboardRef}
-          style={{ position: "absolute", top: 256, pointerEvents: "none" }}
-        />
-        <input
           style={{
             position: "absolute",
-            top: 128,
-            borderWidth: 4,
+            top: 0,
+            opacity: 0,
+            pointerEvents: "none",
           }}
         />
       </>

--- a/fableous-fe/src/components/canvas/Canvas.tsx
+++ b/fableous-fe/src/components/canvas/Canvas.tsx
@@ -76,6 +76,7 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
     const [dragging, setDragging] = useState(false);
     const [hasLifted, setHasLifted] = useState(false);
     const [lastPos, setLastPos] = useState([0, 0]);
+    const [dragOffset, setDragOffset] = useState([0, 0]);
     const [audioB64Strings, setAudioB64Strings] = useState<string[]>([]);
     const [audioMediaRecorder, setAudioMediaRecorder] =
       useState<MediaRecorder>();
@@ -363,9 +364,13 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
           setEditingTextId(0);
         }
       } else if (isEditingText) {
-        if (targetId) {
+        if (targetId && targetShape) {
           // edit clicked text
           setEditingTextId(targetId);
+          setDragOffset([
+            (targetShape.x1 + targetShape.x2) / 2 - x,
+            (targetShape.y1 + targetShape.y2) / 2 - y,
+          ]);
         } else if (editingTextId) {
           // deselect currently editing text
           setEditingTextId(0);
@@ -670,7 +675,13 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
           const shape = textShapesRef.current[editingTextId];
           setDragging(true);
           showKeyboard(false);
-          placeText(x, y, editingTextId, shape.text, shape.fontSize);
+          placeText(
+            x + dragOffset[0],
+            y + dragOffset[1],
+            editingTextId,
+            shape.text,
+            shape.fontSize
+          );
           break;
         case ToolMode.None:
           interactCanvas(x, y, false, true);

--- a/fableous-fe/src/components/canvas/Canvas.tsx
+++ b/fableous-fe/src/components/canvas/Canvas.tsx
@@ -367,6 +367,7 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
         if (targetId) {
           // edit clicked text
           setEditingTextId(targetId);
+          showKeyboard(true);
         } else if (editingTextId) {
           // deselect currently editing text
           setEditingTextId(0);
@@ -377,6 +378,7 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
           setEditingTextId(textId);
           setTextId(textId + 1);
           setHasLifted(true); // disable dragging for new texts
+          showKeyboard(true);
         }
       } else if (targetShape) {
         window.speechSynthesis.speak(
@@ -670,6 +672,7 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
           if (!editingTextId || hasLifted || !allowDrawing) return;
           const shape = textShapesRef.current[editingTextId];
           setDragging(true);
+          showKeyboard(false);
           placeText(x, y, editingTextId, shape.text, shape.fontSize);
           break;
         case ToolMode.None:
@@ -684,9 +687,6 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
       if (!allowDrawing) return;
       if (toolMode === ToolMode.Paint || toolMode === ToolMode.Fill) {
         placeCheckpoint(toolMode);
-      }
-      if (editingTextId && !dragging) {
-        showKeyboard(true);
       }
       if (dragging) {
         setEditingTextId(0);

--- a/fableous-fe/src/components/canvas/Canvas.tsx
+++ b/fableous-fe/src/components/canvas/Canvas.tsx
@@ -811,7 +811,10 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
     useEffect(() => {
       if (isShown && role !== ControllerRole.Hub) {
         if (editingTextId) {
-          setTimeout(() => onScreenKeyboardRef.current.focus(), 100);
+          onScreenKeyboardRef.current.focus();
+          setTimeout(() => onScreenKeyboardRef.current.focus(), 500);
+          console.log(editingTextId);
+          console.log(onScreenKeyboardRef.current);
         } else {
           onScreenKeyboardRef.current.blur();
         }

--- a/fableous-fe/src/containers/HomePage.tsx
+++ b/fableous-fe/src/containers/HomePage.tsx
@@ -40,6 +40,9 @@ export default function HomePage() {
           Student
         </Button>
       </div>
+      {process.env.NODE_ENV === "development" && (
+        <div id="version_tag">{process.env.REACT_APP_VERSION}</div>
+      )}
     </Grid>
   );
 }

--- a/fableous-fe/src/containers/HomePage.tsx
+++ b/fableous-fe/src/containers/HomePage.tsx
@@ -40,9 +40,7 @@ export default function HomePage() {
           Student
         </Button>
       </div>
-      {process.env.NODE_ENV === "development" && (
-        <div id="version_tag">{process.env.REACT_APP_VERSION}</div>
-      )}
+      <div id="version_tag">{process.env.REACT_APP_VERSION}</div>
     </Grid>
   );
 }

--- a/fableous-fe/src/containers/HomePage.tsx
+++ b/fableous-fe/src/containers/HomePage.tsx
@@ -2,6 +2,7 @@ import { Button, Grid, Typography } from "@material-ui/core";
 import { Link } from "react-router-dom";
 
 export default function HomePage() {
+  const version = process.env.REACT_APP_VERSION;
   return (
     <Grid
       container
@@ -40,7 +41,7 @@ export default function HomePage() {
           Student
         </Button>
       </div>
-      <div id="version_tag">{process.env.REACT_APP_VERSION}</div>
+      <div id="version_tag">{version}</div>
     </Grid>
   );
 }

--- a/fableous-fe/src/index.css
+++ b/fableous-fe/src/index.css
@@ -20,11 +20,6 @@ code {
     monospace;
 }
 
-#MOCK_INPUT:focus {
-  border-width: 4px;
-  border-color: aqua;
-}
-
 #version_tag {
   text-align: center;
   font-family: "Courier", monospace;

--- a/fableous-fe/src/index.css
+++ b/fableous-fe/src/index.css
@@ -24,3 +24,13 @@ code {
   border-width: 4px;
   border-color: aqua;
 }
+
+#version_tag {
+  text-align: center;
+  font-family: "Courier", monospace;
+  opacity: 25%;
+  position: absolute;
+  bottom: 64px;
+  user-select: none;
+  pointer-events: none;
+}

--- a/fableous-fe/src/index.css
+++ b/fableous-fe/src/index.css
@@ -19,3 +19,8 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
+
+#MOCK_INPUT:focus {
+  border-width: 4px;
+  border-color: aqua;
+}

--- a/fableous-fe/src/index.css
+++ b/fableous-fe/src/index.css
@@ -23,7 +23,7 @@ code {
 #version_tag {
   text-align: center;
   font-family: "Courier", monospace;
-  opacity: 25%;
+  opacity: 0.2;
   position: absolute;
   bottom: 64px;
   user-select: none;


### PR DESCRIPTION
Canvas listens to keyboard input events to write texts using ToolMode.Text. However, on mobile devices without a physical keyboard, this would not be possible. A plausible solution is to focus on a hidden text input in order to trigger the on-screen keyboard to pop up.