### PR TITLE
[FAB-83] Misaligned gallery text

### DIFF
--- a/fableous-fe/src/components/canvas/Canvas.tsx
+++ b/fableous-fe/src/components/canvas/Canvas.tsx
@@ -848,7 +848,8 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
             e.preventDefault();
           }}
           onClick={() => {
-            if (editingTextId) showKeyboard(true);
+            if (editingTextId && role !== ControllerRole.Hub)
+              showKeyboard(true);
           }}
           style={{
             borderWidth: 4,

--- a/fableous-fe/src/components/canvas/Canvas.tsx
+++ b/fableous-fe/src/components/canvas/Canvas.tsx
@@ -1006,7 +1006,7 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
         )}
         <input
           ref={onScreenKeyboardRef}
-          value={textShapesRef.current[editingTextId]?.text}
+          value={textShapesRef.current[editingTextId]?.text || ""}
           onChange={(e) => {
             onKeyDown(e.target.value);
           }}

--- a/fableous-fe/src/components/canvas/Canvas.tsx
+++ b/fableous-fe/src/components/canvas/Canvas.tsx
@@ -600,10 +600,10 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
                 break;
               case WSMessageType.Text:
                 placeText(msg.data.id || 1, {
-                  normX: msg.data.x1, // use normalized coords
-                  normY: msg.data.y1,
-                  normFontSize: msg.data.width,
-                  text: msg.data.text,
+                  normX: msg.data.x1 || 0, // use normalized coords
+                  normY: msg.data.y1 || 0,
+                  normFontSize: msg.data.width || 0,
+                  text: msg.data.text || "",
                 } as TextShape);
                 break;
               case WSMessageType.Audio:

--- a/fableous-fe/src/components/canvas/Canvas.tsx
+++ b/fableous-fe/src/components/canvas/Canvas.tsx
@@ -777,6 +777,7 @@ const Canvas = forwardRef<HTMLCanvasElement, CanvasProps>(
       setAudioB64Strings([]);
       setTextShapes({});
       setTextId(1);
+      setEditingTextId(0);
       setCheckpointHistory([]);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [pageNum]);

--- a/fableous-fe/src/components/canvas/data.ts
+++ b/fableous-fe/src/components/canvas/data.ts
@@ -1,8 +1,6 @@
 export interface Shape {
-  x1: number;
-  y1: number;
-  x2: number;
-  y2: number;
+  x: number;
+  y: number;
 }
 
 export interface TextShape extends Shape {

--- a/fableous-fe/src/components/canvas/data.ts
+++ b/fableous-fe/src/components/canvas/data.ts
@@ -1,11 +1,11 @@
 export interface Shape {
-  x: number;
-  y: number;
+  normX: number;
+  normY: number;
 }
 
 export interface TextShape extends Shape {
   text: string;
-  fontSize: number;
+  normFontSize: number;
 }
 
 export type TextShapeMap = { [id: number]: TextShape };

--- a/fableous-fe/src/containers/HubCanvasPage.tsx
+++ b/fableous-fe/src/containers/HubCanvasPage.tsx
@@ -182,6 +182,7 @@ export default function HubCanvasPage() {
       .toDataURL("image/png")
       .replace("image/png", "image/octet-stream");
     link.click();
+    console.log(JSON.stringify(storyTextShapes));
   };
 
   const isAllControllersJoined = (): boolean => {

--- a/fableous-fe/src/containers/StoryDetailPage.tsx
+++ b/fableous-fe/src/containers/StoryDetailPage.tsx
@@ -50,10 +50,9 @@ export default function StoryDetailPage() {
   return (
     <Grid container>
       <Grid item xs={12} className="mb-4">
-        {Object.values(manifest?.texts || {}).map((text) => (
-          <Typography variant="h2">new {text.x2}</Typography>
-        ))}
-
+        <Typography variant="h2">
+          new {Object.keys(manifest?.texts || {}).length} texts
+        </Typography>
         <Typography variant="h2">{story?.data?.title}</Typography>
       </Grid>
       {getLoading && (
@@ -81,7 +80,7 @@ export default function StoryDetailPage() {
                     role={ControllerRole.Hub}
                     layer={ControllerRole.Story}
                     pageNum={page}
-                    isGallery
+                    // isGallery
                     setTextShapes={setTextShapes}
                     textShapes={textShapes}
                   />

--- a/fableous-fe/src/containers/StoryDetailPage.tsx
+++ b/fableous-fe/src/containers/StoryDetailPage.tsx
@@ -17,7 +17,7 @@ export default function StoryDetailPage() {
   const canvasRef = useRef<HTMLCanvasElement>(document.createElement("canvas"));
 
   const [
-    { data: story, loading: getLoading, error: getError },
+    { data: story, loading: getStoryLoading, error: getStoryError },
     executeGetClassroomDetail,
   ] = useAxios<APIResponse<Session>, APIResponse<undefined>>(
     restAPI.session.getOne(classroomId, sessionId),
@@ -25,12 +25,13 @@ export default function StoryDetailPage() {
   );
 
   const [page, setPage] = useState(1);
-  const [{ data: manifest }, executeGetManifest] = useAxios<
-    Manifest,
-    undefined
-  >(restAPI.gallery.getAsset(classroomId, sessionId, page, "manifest.json"), {
-    manual: true,
-  });
+  const [{ data: manifest, loading: getManifestLoading }, executeGetManifest] =
+    useAxios<Manifest, undefined>(
+      restAPI.gallery.getAsset(classroomId, sessionId, page, "manifest.json"),
+      {
+        manual: true,
+      }
+    );
 
   useEffect(() => {
     executeGetClassroomDetail();
@@ -55,13 +56,13 @@ export default function StoryDetailPage() {
         </Typography>
         <Typography variant="h2">{story?.data?.title}</Typography>
       </Grid>
-      {getLoading && (
+      {getStoryLoading && (
         <Grid container justifyContent="center">
           <CircularProgress />
         </Grid>
       )}
-      {getError && <Alert severity="error">Failed loading Gallery!</Alert>}
-      {!getLoading && !getError && (
+      {getStoryError && <Alert severity="error">Failed loading Gallery!</Alert>}
+      {!getStoryLoading && !getStoryError && (
         <Grid container spacing={2}>
           {story?.data && (
             <Grid item key={story.data.pages}>
@@ -80,6 +81,12 @@ export default function StoryDetailPage() {
                     role={ControllerRole.Hub}
                     layer={ControllerRole.Story}
                     pageNum={page}
+                    isShown={
+                      !getStoryLoading &&
+                      !!story &&
+                      !getManifestLoading &&
+                      !!manifest
+                    } // ensures canvas is loaded withh proper dimensions
                     isGallery
                     setTextShapes={setTextShapes}
                     textShapes={textShapes}
@@ -103,6 +110,9 @@ export default function StoryDetailPage() {
                       ).url
                     }
                     alt={story.data.title}
+                    style={{
+                      borderWidth: 4,
+                    }}
                   />
                 </div>
               </div>

--- a/fableous-fe/src/containers/StoryDetailPage.tsx
+++ b/fableous-fe/src/containers/StoryDetailPage.tsx
@@ -51,7 +51,7 @@ export default function StoryDetailPage() {
     <Grid container>
       <Grid item xs={12} className="mb-4">
         <Typography variant="h2">
-          new {Object.keys(manifest?.texts || {}).length} texts
+          {Object.keys(manifest?.texts || {}).length} texts
         </Typography>
         <Typography variant="h2">{story?.data?.title}</Typography>
       </Grid>
@@ -80,7 +80,7 @@ export default function StoryDetailPage() {
                     role={ControllerRole.Hub}
                     layer={ControllerRole.Story}
                     pageNum={page}
-                    // isGallery
+                    isGallery
                     setTextShapes={setTextShapes}
                     textShapes={textShapes}
                   />


### PR DESCRIPTION
Previously, our manifest was typed as follows.

```ts
interface Shape {
  normX: number;
  normY: number;
}

interface TextShape extends Shape {
  text: string;
  normFontSize: number;
}
```

However, this brings up an issue where text bounds in the gallery are not properly aligned on different screen resolutions, due to these absolute corodinates.

This fix attempts to turn these absolute coords into relative, refactoring a lot of the text related stuff.