### PR TITLE
Setup colors and approach to customizing mui components

### DIFF
--- a/fableous-fe/src/App.tsx
+++ b/fableous-fe/src/App.tsx
@@ -1,13 +1,56 @@
 import React from "react";
 import { Container, Grid } from "@material-ui/core";
+import { createTheme, ThemeProvider } from "@material-ui/core/styles";
 import { BrowserRouter as Router } from "react-router-dom";
 import { SnackbarProvider } from "notistack";
 import AuthProvider from "./components/AuthProvider";
 import Navbar from "./components/Navbar";
 import Routes from "./Routes";
 import InjectAxiosRespInterceptor from "./components/InjectAxiosRespInterceptor";
+import colors from "./colors";
 
 export default function App() {
+  const theme = createTheme({
+    palette: {
+      primary: {
+        light: colors.blue.light,
+        main: colors.blue.main,
+        dark: colors.blue.dark,
+      },
+      secondary: {
+        light: colors.orange.light,
+        main: colors.orange.main,
+      },
+    },
+    overrides: {
+      MuiChip: {
+        root: {
+          borderRadius: "1.5rem",
+          padding: "0.25rem 1rem",
+          marginRight: "1rem",
+          height: "auto",
+          fontWeight: "bold",
+          "&:last-of-type": {
+            marginRight: 0,
+          },
+        },
+        label: {
+          fontSize: "1.25rem",
+        },
+        colorPrimary: {
+          backgroundColor: colors.orange.main,
+        },
+        colorSecondary: {
+          backgroundColor: colors.orange.light,
+        },
+        outlinedPrimary: {
+          backgroundColor: colors.white,
+          color: colors.blue.light,
+        },
+      },
+    },
+  });
+
   return (
     <div id="app">
       {/* place Snackbar outside of React.StrictMode to suppress finddomnode is deprecated warning */}
@@ -16,12 +59,14 @@ export default function App() {
           <AuthProvider>
             <Router>
               <InjectAxiosRespInterceptor />
-              <Navbar />
-              <Container className="pt-5">
-                <Grid container>
-                  <Routes />
-                </Grid>
-              </Container>
+              <ThemeProvider theme={theme}>
+                <Navbar />
+                <Container className="pt-5">
+                  <Grid container>
+                    <Routes />
+                  </Grid>
+                </Container>
+              </ThemeProvider>
             </Router>
           </AuthProvider>
         </React.StrictMode>

--- a/fableous-fe/src/colors.ts
+++ b/fableous-fe/src/colors.ts
@@ -1,0 +1,12 @@
+export default {
+  orange: {
+    light: "#FF857B",
+    main: "#FF594B",
+  },
+  blue: {
+    light: "#1583D8",
+    main: "#1E5DDD",
+    dark: "#0D44BA",
+  },
+  white: "#FFFFFF",
+};

--- a/fableous-fe/src/containers/ControllerCanvasPage.tsx
+++ b/fableous-fe/src/containers/ControllerCanvasPage.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState, useEffect, useCallback } from "react";
 import Radio from "@material-ui/core/Radio";
+import { makeStyles } from "@material-ui/core/styles";
 import RadioGroup from "@material-ui/core/RadioGroup";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import Button from "@material-ui/core/Button";
@@ -34,6 +35,14 @@ enum ControllerState {
   StoryFinished = "STORY_FINISHED",
 }
 
+const useStyles = makeStyles({
+  disableMobileHoldInteraction: {
+    WebkitTouchCallout: "none",
+    WebkitUserSelect: "none",
+    userSelect: "none",
+  },
+});
+
 export default function ControllerCanvasPage() {
   const { enqueueSnackbar } = useSnackbar();
   const [controllerState, setControllerState] = useState<ControllerState>(
@@ -50,6 +59,7 @@ export default function ControllerCanvasPage() {
     APIResponse<Session>,
     APIResponse<undefined>
   >({});
+  const classes = useStyles();
 
   const canvasRef = useRef<HTMLCanvasElement>(document.createElement("canvas"));
   const [cursor, setCursor] = useState<Cursor | undefined>();
@@ -197,8 +207,12 @@ export default function ControllerCanvasPage() {
   }, [currentPageIdx, storyDetails, controllerState]);
 
   return (
-    <>
-      <Grid item xs={12} className="mb-4">
+    <Grid
+      item
+      container
+      className={`mb-4 ${classes.disableMobileHoldInteraction}`}
+    >
+      <Grid item>
         <Typography variant="h2">
           {
             {
@@ -209,189 +223,181 @@ export default function ControllerCanvasPage() {
             }[controllerState]
           }
         </Typography>
-        <div
-          style={{
-            WebkitTouchCallout: "none",
-            WebkitUserSelect: "none",
-            userSelect: "none",
-          }}
-        >
-          {controllerState === ControllerState.JoinForm && (
-            <Formik
-              initialValues={
-                {
-                  name: "",
-                  token: "",
-                  role: ControllerRole.Story,
-                } as ControllerJoin
-              }
-              validationSchema={yup.object().shape({
-                name: yup.string().required("required"),
-                token: yup
-                  .string()
-                  .required("required")
-                  .length(4, "must be 4 characters")
-                  .uppercase("must be all uppercase characters"),
-              })}
-              onSubmit={handleJoinSession}
-            >
-              {(formik) => (
-                <form onSubmit={formik.handleSubmit}>
-                  <div>
-                    <FormikTextField
-                      formik={formik}
-                      name="name"
-                      label="Name"
-                      overrides={{
-                        autoFocus: true,
-                      }}
-                    />
-                  </div>
-                  <div>
-                    <FormikTextField
-                      formik={formik}
-                      name="token"
-                      label="Token"
-                      overrides={{
-                        onChange: (ev: React.ChangeEvent<HTMLInputElement>) => {
-                          const evUpperCase = { ...ev };
-                          evUpperCase.target.value =
-                            ev.target.value?.toUpperCase();
-                          formik.handleChange(evUpperCase);
-                        },
-                      }}
-                    />
-                  </div>
+        {controllerState === ControllerState.JoinForm && (
+          <Formik
+            initialValues={
+              {
+                name: "",
+                token: "",
+                role: ControllerRole.Story,
+              } as ControllerJoin
+            }
+            validationSchema={yup.object().shape({
+              name: yup.string().required("required"),
+              token: yup
+                .string()
+                .required("required")
+                .length(4, "must be 4 characters")
+                .uppercase("must be all uppercase characters"),
+            })}
+            onSubmit={handleJoinSession}
+          >
+            {(formik) => (
+              <form onSubmit={formik.handleSubmit}>
+                <div>
+                  <FormikTextField
+                    formik={formik}
+                    name="name"
+                    label="Name"
+                    overrides={{
+                      autoFocus: true,
+                    }}
+                  />
+                </div>
+                <div>
+                  <FormikTextField
+                    formik={formik}
+                    name="token"
+                    label="Token"
+                    overrides={{
+                      onChange: (ev: React.ChangeEvent<HTMLInputElement>) => {
+                        const evUpperCase = { ...ev };
+                        evUpperCase.target.value =
+                          ev.target.value?.toUpperCase();
+                        formik.handleChange(evUpperCase);
+                      },
+                    }}
+                  />
+                </div>
 
-                  <RadioGroup
-                    name="role"
-                    value={formik.values.role}
-                    onChange={formik.handleChange}
-                    onBlur={formik.handleBlur}
-                  >
-                    <FormControlLabel
-                      value={ControllerRole.Story}
-                      control={<Radio />}
-                      label="Story"
-                    />
-                    <FormControlLabel
-                      value={ControllerRole.Character}
-                      control={<Radio />}
-                      label="Character"
-                    />
-                    <FormControlLabel
-                      value={ControllerRole.Background}
-                      control={<Radio />}
-                      label="Background"
-                    />
-                  </RadioGroup>
-                  <Button type="submit">Join Session</Button>
-                </form>
-              )}
-            </Formik>
+                <RadioGroup
+                  name="role"
+                  value={formik.values.role}
+                  onChange={formik.handleChange}
+                  onBlur={formik.handleBlur}
+                >
+                  <FormControlLabel
+                    value={ControllerRole.Story}
+                    control={<Radio />}
+                    label="Story"
+                  />
+                  <FormControlLabel
+                    value={ControllerRole.Character}
+                    control={<Radio />}
+                    label="Character"
+                  />
+                  <FormControlLabel
+                    value={ControllerRole.Background}
+                    control={<Radio />}
+                    label="Background"
+                  />
+                </RadioGroup>
+                <Button type="submit">Join Session</Button>
+              </form>
+            )}
+          </Formik>
+        )}
+        <div
+          className={
+            controllerState !== ControllerState.JoinForm ? "block" : "hidden"
+          }
+        >
+          {/* TODO keep it one row regardless of screen size */}
+          <div className="flex flex-wrap justify-between gap-y-4">
+            <div className="flex">
+              <Chip label={`Title: ${storyDetails?.title}`} color="primary" />
+              {storyDetails?.description.split(",").map((tag) => (
+                <Chip label={tag} color="secondary" key={tag} />
+              ))}
+            </div>
+            <div className="flex">
+              <Chip
+                label={`Role: ${
+                  role[0].toUpperCase() + role.slice(1).toLowerCase()
+                }`}
+                color="primary"
+                variant="outlined"
+              />
+              <Chip
+                label={`Page ${currentPageIdx} of ${
+                  storyDetails?.pages || "-"
+                }`}
+                color="primary"
+                variant="outlined"
+              />
+            </div>
+          </div>
+          {controllerState === ControllerState.WaitingRoom && (
+            <Typography variant="h6" component="p">
+              waiting for hub to start..
+            </Typography>
+          )}
+          {controllerState === ControllerState.StoryFinished && (
+            <>
+              <div>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  className="mb-2"
+                  onClick={() => {
+                    setControllerState(ControllerState.JoinForm);
+                  }}
+                >
+                  Join another session
+                </Button>
+              </div>
+              <div>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  component={Link}
+                  to={`/gallery/${sessionInfo?.classroomId}/${sessionInfo?.sessionId}`}
+                >
+                  View story in gallery
+                </Button>
+              </div>
+            </>
           )}
           <div
             className={
-              controllerState !== ControllerState.JoinForm ? "block" : "hidden"
+              controllerState === ControllerState.DrawingSession
+                ? "grid"
+                : "hidden"
             }
           >
-            {/* TODO keep it one row regardless of screen size */}
-            <div className="flex flex-wrap justify-between gap-y-4">
-              <div className="flex">
-                <Chip label={`Title: ${storyDetails?.title}`} color="primary" />
-                {storyDetails?.description.split(",").map((tag) => (
-                  <Chip label={tag} color="secondary" key={tag} />
-                ))}
-              </div>
-              <div className="flex">
-                <Chip
-                  label={`Role: ${
-                    role[0].toUpperCase() + role.slice(1).toLowerCase()
-                  }`}
-                  color="primary"
-                  variant="outlined"
-                />
-                <Chip
-                  label={`Page ${currentPageIdx} of ${
-                    storyDetails?.pages || "-"
-                  }`}
-                  color="primary"
-                  variant="outlined"
-                />
-              </div>
-            </div>
-            {controllerState === ControllerState.WaitingRoom && (
-              <Typography variant="h6" component="p">
-                waiting for hub to start..
-              </Typography>
-            )}
-            {controllerState === ControllerState.StoryFinished && (
-              <>
-                <div>
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    className="mb-2"
-                    onClick={() => {
-                      setControllerState(ControllerState.JoinForm);
-                    }}
-                  >
-                    Join another session
-                  </Button>
-                </div>
-                <div>
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    component={Link}
-                    to={`/gallery/${sessionInfo?.classroomId}/${sessionInfo?.sessionId}`}
-                  >
-                    View story in gallery
-                  </Button>
-                </div>
-              </>
-            )}
             <div
-              className={
-                controllerState === ControllerState.DrawingSession
-                  ? "grid"
-                  : "hidden"
-              }
+              style={{
+                gridRowStart: 1,
+                gridColumnStart: 1,
+                zIndex: 20,
+                pointerEvents: "none", // forwards pointer events to next layer
+              }}
             >
-              <div
-                style={{
-                  gridRowStart: 1,
-                  gridColumnStart: 1,
-                  zIndex: 20,
-                  pointerEvents: "none", // forwards pointer events to next layer
-                }}
-              >
-                <CursorScreen
-                  cursor={cursor}
-                  isShown={controllerState === ControllerState.DrawingSession}
-                />
-              </div>
-              <div
-                style={{
-                  gridRowStart: 1,
-                  gridColumnStart: 1,
-                  zIndex: 10,
-                }}
-              >
-                <Canvas
-                  ref={canvasRef}
-                  wsConn={wsConn}
-                  role={role}
-                  layer={role}
-                  pageNum={currentPageIdx}
-                  isShown={controllerState === ControllerState.DrawingSession}
-                  setCursor={setCursor}
-                />
-              </div>
+              <CursorScreen
+                cursor={cursor}
+                isShown={controllerState === ControllerState.DrawingSession}
+              />
+            </div>
+            <div
+              style={{
+                gridRowStart: 1,
+                gridColumnStart: 1,
+                zIndex: 10,
+              }}
+            >
+              <Canvas
+                ref={canvasRef}
+                wsConn={wsConn}
+                role={role}
+                layer={role}
+                pageNum={currentPageIdx}
+                isShown={controllerState === ControllerState.DrawingSession}
+                setCursor={setCursor}
+              />
             </div>
           </div>
         </div>
       </Grid>
-    </>
+    </Grid>
   );
 }

--- a/fableous-fe/src/containers/ControllerCanvasPage.tsx
+++ b/fableous-fe/src/containers/ControllerCanvasPage.tsx
@@ -10,6 +10,7 @@ import Typography from "@material-ui/core/Typography";
 import * as yup from "yup";
 import { Formik, FormikHelpers } from "formik";
 import { useSnackbar } from "notistack";
+import { Chip } from "@material-ui/core";
 import Canvas from "../components/canvas/Canvas";
 import {
   APIResponse,
@@ -202,14 +203,12 @@ export default function ControllerCanvasPage() {
           {
             {
               [ControllerState.JoinForm]: "join",
-              [ControllerState.WaitingRoom]: "draw",
-              [ControllerState.DrawingSession]: "draw",
+              [ControllerState.WaitingRoom]: "",
+              [ControllerState.DrawingSession]: "",
               [ControllerState.StoryFinished]: "finished",
             }[controllerState]
           }
         </Typography>
-      </Grid>
-      <Grid item xs={12}>
         <div
           style={{
             WebkitTouchCallout: "none",
@@ -296,16 +295,31 @@ export default function ControllerCanvasPage() {
               controllerState !== ControllerState.JoinForm ? "block" : "hidden"
             }
           >
-            <Typography variant="h6">Role: {role}</Typography>
-            <Typography variant="h6">Title: {storyDetails?.title}</Typography>
-            <Typography variant="h6">
-              Description: {storyDetails?.description}
-            </Typography>
-            {controllerState === ControllerState.DrawingSession && (
-              <Typography variant="h6">
-                page {currentPageIdx || "-"} of {storyDetails?.pages || "-"}
-              </Typography>
-            )}
+            {/* TODO keep it one row regardless of screen size */}
+            <div className="flex flex-wrap justify-between gap-y-4">
+              <div className="flex">
+                <Chip label={`Title: ${storyDetails?.title}`} color="primary" />
+                {storyDetails?.description.split(",").map((tag) => (
+                  <Chip label={tag} color="secondary" key={tag} />
+                ))}
+              </div>
+              <div className="flex">
+                <Chip
+                  label={`Role: ${
+                    role[0].toUpperCase() + role.slice(1).toLowerCase()
+                  }`}
+                  color="primary"
+                  variant="outlined"
+                />
+                <Chip
+                  label={`Page ${currentPageIdx} of ${
+                    storyDetails?.pages || "-"
+                  }`}
+                  color="primary"
+                  variant="outlined"
+                />
+              </div>
+            </div>
             {controllerState === ControllerState.WaitingRoom && (
               <Typography variant="h6" component="p">
                 waiting for hub to start..

--- a/fableous-fe/src/containers/ControllerCanvasPage.tsx
+++ b/fableous-fe/src/containers/ControllerCanvasPage.tsx
@@ -214,7 +214,7 @@ export default function ControllerCanvasPage() {
       container
       className={`mb-4 ${classes.disableMobileHoldInteraction}`}
     >
-      <Grid item>
+      <Grid item xs={12}>
         <Typography variant="h2">
           {
             {


### PR DESCRIPTION
Setup color hexes used in `colors.ts` then applies default styling customization with mui's theme, an example in this PR is `<Chip />` component, others using it will directly have matching appearance to prototype, a downside is that tailwind cannot be used as mui theme involves css properties not classnames and that the theme customization will get large later on.

An alternative is to create our own `<CustomChip />` component that modifies mui's `<Chip />` styling to our needs, but this makes devs have to look if we already have a custom component. With us trying to match the prototype, I dont think we will ever need the vanila `<Chip />` styling, so Im leaning towards using mui theme.

For something that we already have as a component e.g. NavBar, styling customization can be applied there directly.

todo

- [x] fix positioning of chips in waiting room